### PR TITLE
Fix some titles

### DIFF
--- a/src/pages/guide/Layouts.svelte
+++ b/src/pages/guide/Layouts.svelte
@@ -1,7 +1,9 @@
 <!-- routify:options $index=40 -->
 <!-- routify:options $name="Layouts (soon)" -->
 
+<script>
+  import { meta } from "@sveltech/routify";
+  meta.title = "Layouts";
+</script>
 
-
-
-<h1 class="c-h1">Layouts (Comming soon)</h1>
+<h1 class="c-h1">Layouts (Coming soon)</h1>

--- a/src/pages/guide/Parameters.svelte
+++ b/src/pages/guide/Parameters.svelte
@@ -4,4 +4,4 @@
 
 
 
-<h1 class="c-h1">Parameters (Comming soon)</h1>
+<h1 class="c-h1">Parameters (Coming soon)</h1>

--- a/src/pages/guide/install-to-existing-project.svelte
+++ b/src/pages/guide/install-to-existing-project.svelte
@@ -6,10 +6,10 @@
 </script>
 
 <!-- routify:options $index=20 -->
-<!-- routify:options $name="Install to existing project" -->
+<!-- routify:options $name="Install in an existing project" -->
 
 <div class="c-container-vertical--small">
-  <h1 class="c-h1" use:focus>Install in existing project</h1>
+  <h1 class="c-h1" use:focus>Install in an existing project</h1>
   <p>
     This is a guide for installing Routify in an existing project. If you wish
     to create a new project instead. Please refer to our

--- a/src/pages/guide/navigation.svelte
+++ b/src/pages/guide/navigation.svelte
@@ -1,7 +1,9 @@
+<script>
+  import { meta } from "@sveltech/routify";
+  meta.title = "Navigation";
+</script>
+
 <!-- routify:options $index=60 -->
 <!-- routify:options $name="Navigation (soon)" -->
 
-
-
-
-<h1 class="c-h1">Navigation (Comming soon)</h1>
+<h1 class="c-h1">Navigation (Coming soon)</h1>

--- a/src/pages/guide/pages.svelte
+++ b/src/pages/guide/pages.svelte
@@ -4,4 +4,4 @@
 
 
 
-<h1 class="c-h1">Pages (Comming soon)</h1>
+<h1 class="c-h1">Pages (Coming soon)</h1>

--- a/src/pages/introduction/getting-started.svelte
+++ b/src/pages/introduction/getting-started.svelte
@@ -2,7 +2,7 @@
   import { url, meta } from "@sveltech/routify";
   import Prism from "svelte-prism";
   import { Tabs, TabsLink, TabsPage } from "@sveltech/bricks";
-  meta.title = "What is Routify";
+  meta.title = "Getting started";
   import Note from "@/components/Note.svelte";
 </script>
 

--- a/src/pages/introduction/parameters.svelte
+++ b/src/pages/introduction/parameters.svelte
@@ -1,7 +1,7 @@
 <script>
   import Prism from "svelte-prism";
   import { meta } from "@sveltech/routify";
-  meta.title = "Decorators";
+  meta.title = "URL parameters";
 </script>
 <!-- routify:options $index=30 -->
 


### PR DESCRIPTION
Cleaner titles for the pages under “Introduction”.

Under “Helpers” it seems like things work in a different way and I can't simply use the meta thing, because we refer to # anchors in the nav.

At least this is is a fix already for some of the titles which can be merged.