### PR TITLE
rename $params -> $context

### DIFF
--- a/src/pages/docs/helpers/_helpers/context.svelte
+++ b/src/pages/docs/helpers/_helpers/context.svelte
@@ -8,7 +8,7 @@
 <FunctionDoc name="$context" type="object">
   <p>
     Use
-    <code>$params</code>
+    <code>$context</code>
     to access the current component context.
   </p>
 


### PR DESCRIPTION
I spotted this while reading the docs