### PR TITLE
Fixes broken link to Getting Started Guide

### DIFF
--- a/src/pages/guide/installation/install-to-existing-project.svelte
+++ b/src/pages/guide/installation/install-to-existing-project.svelte
@@ -14,7 +14,7 @@
     <p>
       This is a guide for installing Routify in an existing project. If you wish
       to create a new project instead. Please refer to our
-      <a href={$url('../../getting-started')}>getting started guide</a>.
+      <a href={$url('/guide/introduction/getting-started')}>getting started guide</a>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
Link to "Getting Started Guide" is incorrect and gives 404-Page Not Found Error.

Goes to: "/guide/getting-started"
Should go to: "/guide/introduction/getting-started"

I am new to Routify (hence reading the Guide)

It seems like the URL parameter can be relative or absolute.

Relative
<a href={$url('../../introduction/getting-started')}>getting started guide</a>.

Absolute
<a href={$url('/guide/introduction/getting-started')}>getting started guide</a>.

I chose the absolute option