### PR TITLE
Fix `Handling multiple links` guide

### DIFF
--- a/src/pages/guide/navigation.svelte
+++ b/src/pages/guide/navigation.svelte
@@ -113,8 +113,8 @@
     <ul>
       {#each links as [path, name]}
         <!-- Svelte magic. If isActive is true, the "active" class is applied. -->
-        <li class:active={$isActive({path})}>
-          <a href={$url({path})}>
+        <li class:active={$isActive(path)}>
+          <a href={$url(path)}>
             {name}
           </a>
         </li>


### PR DESCRIPTION
The arguments to `url()` and `isActive()` should be strings not objects.