### PR TITLE
Fix invalid Svelte syntax

### DIFF
--- a/src/pages/guide/introduction/parameters.svelte
+++ b/src/pages/guide/introduction/parameters.svelte
@@ -42,7 +42,7 @@
   <Prism>
     {`
         import { params } from '@sveltech/routify'
-        $: { slug } = $params
+        $: slug = $params.slug
     `}
   </Prism>
 


### PR DESCRIPTION
It seems that the following syntax is invalid with Svelte:

```svelte
$: { slug } = $params
```

We must do:

```svelte
$: slug = $params.slug
```

That's what is done in routify-example-tvshow on codesandbox (it's done on `scoped` instead of `$params` but that's the same idea): https://codesandbox.io/s/github/sveltech/routify-example-tvshow/tree/6-navigation?file=/src/pages/shows/%5Bid%5D/index.svelte