### PR TITLE
Update getting-started.svelte

### DIFF
--- a/src/pages/guide/introduction/getting-started.svelte
+++ b/src/pages/guide/introduction/getting-started.svelte
@@ -39,7 +39,7 @@
       help you put your app into production much faster.
     </p>
   </div>
-    <a class="c-button c-button--primary" href={$url('../installation')}>
+    <a class="c-button c-button--primary" href={$url('./installation')}>
       Install
     </a>
 </div>


### PR DESCRIPTION
Link to installation page is currently wrong. The link appears to be [`https://v1.routify.dev/guide/installation`](https://v1.routify.dev/guide/installation) as opposed to [`https://v1.routify.dev/installation`](https://v1.routify.dev/installation).