### PR TITLE
Updated install command since routify init is deprecated

### DIFF
--- a/src/pages/guide/installation/creating-an-app.svelte
+++ b/src/pages/guide/installation/creating-an-app.svelte
@@ -12,7 +12,7 @@
     <h1 class="c-h1">Creating an app</h1>
     <p>To create your first Routify app, open an empty folder and type</p>
 
-    <Code>{`npx @roxi/routify init`}</Code>
+    <Code>{`npm init routify`}</Code>
 
     <p>
       This will install the


### PR DESCRIPTION
routify init is deprecated (according to the CLI's warning messages). The CLI suggests that users use `npm init routify` instead. This should be updated on the docs as well.