### PR TITLE
docs: update init command

### DIFF
--- a/src/pages/guide/installation/creating-an-app.svelte
+++ b/src/pages/guide/installation/creating-an-app.svelte
@@ -12,7 +12,7 @@
     <h1 class="c-h1">Creating an app</h1>
     <p>To create your first Routify app, open an empty folder and type</p>
 
-    <Code>{`npx @roxi/routify init`}</Code>
+    <Code>{`npm init routify`}</Code>
 
     <p>
       This will install the


### PR DESCRIPTION
With the previous docs, here's the behavior that this PR is correcting
```
$ npx @roxi/routify init
Need to install the following packages:
  @roxi/routify@2.18.11
Ok to proceed? (y) y
 ⚠ routify init is deprecated!
   > Please use npm init routify instead
```

Now docs say `npm init routify `